### PR TITLE
Fix destination in ShipmentDeliveredEvent

### DIFF
--- a/deliveryservice/src/main/java/com/luckypets/logistics/deliveryservice/service/DeliveryServiceImpl.java
+++ b/deliveryservice/src/main/java/com/luckypets/logistics/deliveryservice/service/DeliveryServiceImpl.java
@@ -82,7 +82,7 @@ public class DeliveryServiceImpl implements DeliveryService {
         // Send event
         ShipmentDeliveredEvent event = new ShipmentDeliveredEvent(
                 savedShipment.getShipmentId(),
-                savedShipment.getOrigin(),
+                savedShipment.getDestination(),
                 savedShipment.getLastLocation(),
                 LocalDateTime.now(),
                 UUID.randomUUID().toString()


### PR DESCRIPTION
## Summary
- correct destination field when producing `ShipmentDeliveredEvent`

## Testing
- `mvn` unavailable so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_683f408ea678832cae79bdabcdf59841