### PR TITLE
Add destination check in delivery service test

### DIFF
--- a/deliveryservice/src/test/java/com/luckypets/logistics/deliveryservice/unittest/service/DeliveryServiceImplTest.java
+++ b/deliveryservice/src/test/java/com/luckypets/logistics/deliveryservice/unittest/service/DeliveryServiceImplTest.java
@@ -42,6 +42,7 @@ class DeliveryServiceImplTest {
     private ShipmentEntity testShipment;
     private static final String SHIPMENT_ID = "SHIP-001";
     private static final String LOCATION = "Berlin";
+    private static final String DESTINATION = "Berlin";
 
     @BeforeEach
     void setUp() {
@@ -50,7 +51,7 @@ class DeliveryServiceImplTest {
         testShipment.setStatus(ShipmentStatus.IN_TRANSIT);
         testShipment.setLastLocation("WAREHOUSE_A");
         testShipment.setOrigin("Munich");
-        testShipment.setDestination(LOCATION);
+        testShipment.setDestination(DESTINATION);
         testShipment.setCreatedAt(LocalDateTime.now().minusDays(1));
     }
 
@@ -169,6 +170,7 @@ class DeliveryServiceImplTest {
         verify(eventProducer).sendShipmentDeliveredEvent(eventCaptor.capture());
         ShipmentDeliveredEvent event = eventCaptor.getValue();
         assertEquals(SHIPMENT_ID, event.getShipmentId());
+        assertEquals(DESTINATION, event.getDestination());
         assertEquals(LOCATION, event.getLocation());
         assertNotNull(event.getCorrelationId());
     }


### PR DESCRIPTION
## Summary
- ensure DeliveryServiceImpl publishes ShipmentDeliveredEvent with destination property

## Testing
- `mvn -q -pl deliveryservice test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4429eb18832ca90d38725ac88b25