### PR TITLE
Add service layer to analytics and notification modules

### DIFF
--- a/analyticservice/src/main/java/com/luckypets/logistics/analyticservice/service/AnalyticsService.java
+++ b/analyticservice/src/main/java/com/luckypets/logistics/analyticservice/service/AnalyticsService.java
@@ -1,0 +1,19 @@
+package com.luckypets.logistics.analyticservice.service;
+
+import com.luckypets.logistics.shared.events.ShipmentAnalyticsEvent;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+
+/**
+ * Service for building the analytics stream processing topology.
+ */
+public interface AnalyticsService {
+
+    /**
+     * Build the analytics stream that aggregates delivered shipments per location.
+     *
+     * @param builder the StreamsBuilder to use for topology construction
+     * @return the resulting analytics {@link KStream}
+     */
+    KStream<String, ShipmentAnalyticsEvent> buildAnalyticsStream(StreamsBuilder builder);
+}

--- a/analyticservice/src/main/java/com/luckypets/logistics/analyticservice/service/AnalyticsServiceImpl.java
+++ b/analyticservice/src/main/java/com/luckypets/logistics/analyticservice/service/AnalyticsServiceImpl.java
@@ -1,11 +1,12 @@
-package com.luckypets.logistics.analyticservice;
+package com.luckypets.logistics.analyticservice.service;
 
-import com.luckypets.logistics.shared.events.ShipmentDeliveredEvent;
 import com.luckypets.logistics.shared.events.ShipmentAnalyticsEvent;
+import com.luckypets.logistics.shared.events.ShipmentDeliveredEvent;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.*;
+import com.luckypets.logistics.analyticservice.DeliveredAtTimestampExtractor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,27 +15,32 @@ import org.springframework.kafka.support.serializer.JsonSerde;
 import java.time.Duration;
 import java.time.Instant;
 
+/**
+ * Implementation of {@link AnalyticsService} that creates the Kafka Streams topology
+ * for aggregating delivered shipments per location.
+ */
 @Configuration
-public class ShipmentAnalyticsStream {
+public class AnalyticsServiceImpl implements AnalyticsService {
 
-    @org.springframework.beans.factory.annotation.Value("${kafka.topic.delivered:shipment-delivered}")
+    @Value("${kafka.topic.delivered:shipment-delivered}")
     private String deliveredTopic;
 
-    @org.springframework.beans.factory.annotation.Value("${kafka.topic.analytics:shipment-analytics}")
+    @Value("${kafka.topic.analytics:shipment-analytics}")
     private String analyticsTopic;
 
-    public ShipmentAnalyticsStream(
+    public AnalyticsServiceImpl(
             @Value("${kafka.topic.delivered:shipment-delivered}") String deliveredTopic,
             @Value("${kafka.topic.analytics:shipment-analytics}") String analyticsTopic) {
         this.deliveredTopic = deliveredTopic;
         this.analyticsTopic = analyticsTopic;
     }
 
-    public ShipmentAnalyticsStream() {
+    public AnalyticsServiceImpl() {
     }
 
+    @Override
     @Bean
-    public KStream<String, ShipmentAnalyticsEvent> analyticsStream(StreamsBuilder builder) {
+    public KStream<String, ShipmentAnalyticsEvent> buildAnalyticsStream(StreamsBuilder builder) {
         JsonSerde<ShipmentDeliveredEvent> inputSerde = new JsonSerde<>(ShipmentDeliveredEvent.class);
         JsonSerde<ShipmentAnalyticsEvent> outputSerde = new JsonSerde<>(ShipmentAnalyticsEvent.class);
 

--- a/analyticservice/src/test/java/com/luckypets/logistics/analyticservice/ShipmentAnalyticsStreamTest.java
+++ b/analyticservice/src/test/java/com/luckypets/logistics/analyticservice/ShipmentAnalyticsStreamTest.java
@@ -2,6 +2,8 @@ package com.luckypets.logistics.analyticservice;
 
 import com.luckypets.logistics.shared.events.ShipmentAnalyticsEvent;
 import com.luckypets.logistics.shared.events.ShipmentDeliveredEvent;
+import com.luckypets.logistics.analyticservice.service.AnalyticsService;
+import com.luckypets.logistics.analyticservice.service.AnalyticsServiceImpl;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.*;
 import org.apache.kafka.streams.test.TestRecord;
@@ -24,14 +26,14 @@ public class ShipmentAnalyticsStreamTest {
     private TopologyTestDriver testDriver;
     private TestInputTopic<String, ShipmentDeliveredEvent> inputTopic;
     private TestOutputTopic<String, ShipmentAnalyticsEvent> outputTopic;
-    private ShipmentAnalyticsStream analyticsStream;
+    private AnalyticsService analyticsService;
 
     @BeforeEach
     void setUp() {
         // Stream-Topologie erstellen
         StreamsBuilder builder = new StreamsBuilder();
-        analyticsStream = new ShipmentAnalyticsStream("shipment-delivered", "shipment-analytics");
-        analyticsStream.analyticsStream(builder);
+        analyticsService = new AnalyticsServiceImpl("shipment-delivered", "shipment-analytics");
+        analyticsService.buildAnalyticsStream(builder);
         Topology topology = builder.build();
 
         // Kafka Streams Eigenschaften

--- a/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/controller/NotificationController.java
+++ b/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/controller/NotificationController.java
@@ -1,7 +1,7 @@
 package com.luckypets.logistics.notificationservice.controller;
 
 import com.luckypets.logistics.notificationservice.model.Notification;
-import com.luckypets.logistics.notificationservice.repository.NotificationRepository;
+import com.luckypets.logistics.notificationservice.service.NotificationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,33 +11,33 @@ import java.util.List;
 @RequestMapping("/api/notifications")
 public class NotificationController {
 
-    private final NotificationRepository repository;
+    private final NotificationService service;
 
-    public NotificationController(NotificationRepository repository) {
-        this.repository = repository;
+    public NotificationController(NotificationService service) {
+        this.service = service;
     }
 
     @GetMapping
     public List<Notification> getAllNotifications() {
-        return repository.findAll();
+        return service.findAll();
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<Notification> getNotificationById(@PathVariable(name = "id") String id) {
-        return repository.findById(id)
+        return service.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/shipment/{shipmentId}")
     public List<Notification> getNotificationsByShipmentId(@PathVariable(name = "shipmentId") String shipmentId) {
-        return repository.findByShipmentId(shipmentId);
+        return service.findByShipmentId(shipmentId);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteNotification(@PathVariable(name = "id") String id) {
-        if (repository.findById(id).isPresent()) {
-            repository.deleteById(id);
+        if (service.findById(id).isPresent()) {
+            service.deleteById(id);
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.notFound().build();
@@ -45,7 +45,7 @@ public class NotificationController {
 
     @DeleteMapping
     public ResponseEntity<Void> deleteAllNotifications() {
-        repository.deleteAll();
+        service.deleteAll();
         return ResponseEntity.noContent().build();
     }
 }

--- a/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/listener/ShipmentEventListener.java
+++ b/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/listener/ShipmentEventListener.java
@@ -2,7 +2,7 @@ package com.luckypets.logistics.notificationservice.listener;
 
 import com.luckypets.logistics.notificationservice.model.Notification;
 import com.luckypets.logistics.notificationservice.model.NotificationType;
-import com.luckypets.logistics.notificationservice.repository.NotificationRepository;
+import com.luckypets.logistics.notificationservice.service.NotificationService;
 import com.luckypets.logistics.shared.events.ShipmentCreatedEvent;
 import com.luckypets.logistics.shared.events.ShipmentScannedEvent;
 import com.luckypets.logistics.shared.events.ShipmentDeliveredEvent;
@@ -15,10 +15,10 @@ import org.springframework.stereotype.Service;
 public class ShipmentEventListener {
 
     private static final Logger logger = LoggerFactory.getLogger(ShipmentEventListener.class);
-    private final NotificationRepository repository;
+    private final NotificationService service;
 
-    public ShipmentEventListener(NotificationRepository repository) {
-        this.repository = repository;
+    public ShipmentEventListener(NotificationService service) {
+        this.service = service;
     }
 
     @KafkaListener(topics = "shipment-created", groupId = "notification-service")
@@ -32,7 +32,7 @@ public class ShipmentEventListener {
                 NotificationType.SHIPMENT_CREATED
         );
         
-        repository.save(notification);
+        service.save(notification);
         logger.info("Saved notification: {}", notification);
     }
 
@@ -47,7 +47,7 @@ public class ShipmentEventListener {
                 NotificationType.SHIPMENT_SCANNED
         );
         
-        repository.save(notification);
+        service.save(notification);
         logger.info("Saved notification: {}", notification);
     }
 
@@ -62,7 +62,7 @@ public class ShipmentEventListener {
                 NotificationType.SHIPMENT_DELIVERED
         );
         
-        repository.save(notification);
+        service.save(notification);
         logger.info("Saved notification: {}", notification);
     }
 }

--- a/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/service/NotificationService.java
+++ b/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/service/NotificationService.java
@@ -1,0 +1,55 @@
+package com.luckypets.logistics.notificationservice.service;
+
+import com.luckypets.logistics.notificationservice.model.Notification;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Service for managing notifications stored by the notification service.
+ */
+public interface NotificationService {
+
+    /**
+     * Persist a notification.
+     *
+     * @param notification the notification to save
+     * @return the saved notification
+     */
+    Notification save(Notification notification);
+
+    /**
+     * Retrieve all notifications.
+     *
+     * @return list of notifications
+     */
+    List<Notification> findAll();
+
+    /**
+     * Find a notification by its id.
+     *
+     * @param id notification id
+     * @return the notification if present
+     */
+    Optional<Notification> findById(String id);
+
+    /**
+     * Find all notifications for a specific shipment.
+     *
+     * @param shipmentId the shipment id
+     * @return list of notifications
+     */
+    List<Notification> findByShipmentId(String shipmentId);
+
+    /**
+     * Delete a notification by id.
+     *
+     * @param id notification id
+     */
+    void deleteById(String id);
+
+    /**
+     * Delete all stored notifications.
+     */
+    void deleteAll();
+}

--- a/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/service/NotificationServiceImpl.java
+++ b/notificationservice/src/main/java/com/luckypets/logistics/notificationservice/service/NotificationServiceImpl.java
@@ -1,0 +1,51 @@
+package com.luckypets.logistics.notificationservice.service;
+
+import com.luckypets.logistics.notificationservice.model.Notification;
+import com.luckypets.logistics.notificationservice.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Default implementation of {@link NotificationService} using {@link NotificationRepository}.
+ */
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository repository;
+
+    public NotificationServiceImpl(NotificationRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Notification save(Notification notification) {
+        return repository.save(notification);
+    }
+
+    @Override
+    public List<Notification> findAll() {
+        return repository.findAll();
+    }
+
+    @Override
+    public Optional<Notification> findById(String id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<Notification> findByShipmentId(String shipmentId) {
+        return repository.findByShipmentId(shipmentId);
+    }
+
+    @Override
+    public void deleteById(String id) {
+        repository.deleteById(id);
+    }
+
+    @Override
+    public void deleteAll() {
+        repository.deleteAll();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `AnalyticsService` and `AnalyticsServiceImpl` for analytics-service
- refactor stream tests to use the new analytics service
- add `NotificationService` and `NotificationServiceImpl`
- update controller and event listener to use the notification service

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68402c4b1bfc832c950d3c34f67a3901